### PR TITLE
Update CLI to use latest Terraform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,8 @@ jobs:
             - run:
                 name: build the resource pack
                 command: |
-                    zip -r resources.zip target/resources
+                    cd target/resources
+                    zip -r resources.zip resources
             - aws-s3/copy:
                 from: ~/.go_workspace/src/github.com/renproject/darknode-cli/resources.zip
                 to: 's3://releases.republicprotocol.com/darknode-cli/resources-test.zip'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,19 +77,19 @@ jobs:
                     sudo pip install awscli
             - aws-s3/copy:
                 from: ~/.go_workspace/src/github.com/renproject/darknode-cli/darknode_linux_amd64
-                to: 's3://releases.republicprotocol.com/darknode-cli/darknode_linux_amd64-test'
+                to: 's3://releases.republicprotocol.com/darknode-cli/darknode_linux_amd64'
                 arguments: '--acl public-read'
             - aws-s3/copy:
                 from: ~/.go_workspace/src/github.com/renproject/darknode-cli/darknode_darwin_amd64
-                to: 's3://releases.republicprotocol.com/darknode-cli/darknode_darwin_amd64-test'
+                to: 's3://releases.republicprotocol.com/darknode-cli/darknode_darwin_amd64'
                 arguments: '--acl public-read'
             - aws-s3/copy:
                 from: ~/.go_workspace/src/github.com/renproject/darknode-cli/scripts/install.sh
-                to: 's3://releases.republicprotocol.com/darknode-cli/install-test.sh'
+                to: 's3://releases.republicprotocol.com/darknode-cli/install.sh'
                 arguments: '--acl public-read'
             - aws-s3/copy:
                 from: ~/.go_workspace/src/github.com/renproject/darknode-cli/scripts/update.sh
-                to: 's3://releases.republicprotocol.com/darknode-cli/update-test.sh'
+                to: 's3://releases.republicprotocol.com/darknode-cli/update.sh'
                 arguments: '--acl public-read'
             - run:
                 name: build the resource pack
@@ -99,7 +99,7 @@ jobs:
                     mv resources.zip ../
             - aws-s3/copy:
                 from: ~/.go_workspace/src/github.com/renproject/darknode-cli/resources.zip
-                to: 's3://releases.republicprotocol.com/darknode-cli/resources-test.zip'
+                to: 's3://releases.republicprotocol.com/darknode-cli/resources.zip'
                 arguments: '--acl public-read'
 
 workflows:
@@ -111,4 +111,3 @@ workflows:
                     branches:
                         only:
                             - master
-                            - terraform0.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 version: 2.1
 
 orbs:
-    core: ren/ren/core@0.0.1
+    core: ren/core@0.0.1
     aws-s3: circleci/aws-s3@1.0.0
 
 _defaults: &defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 version: 2.1
 
 orbs:
-    core: ren/circleci-orbs@dev:first
+    core: ren/ren/core@0.0.1
     aws-s3: circleci/aws-s3@1.0.0
 
 _defaults: &defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,8 @@ workflows:
     build:
         jobs:
             - deploy:
-#                filters:
-#                    branches:
-#                        only: master
+                filters:
+                    branches:
+                        only:
+                            - master
+                            - terraform0.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,27 @@ jobs:
                     sudo pip install awscli
             - aws-s3/copy:
                 from: ~/.go_workspace/src/github.com/renproject/darknode-cli/darknode_linux_amd64
-                to: 's3://releases.republicprotocol.com/darknode-cli/darknode_linux_amd64'
+                to: 's3://releases.republicprotocol.com/darknode-cli/darknode_linux_amd64-test'
                 arguments: '--acl public-read'
             - aws-s3/copy:
                 from: ~/.go_workspace/src/github.com/renproject/darknode-cli/darknode_darwin_amd64
-                to: 's3://releases.republicprotocol.com/darknode-cli/darknode_darwin_amd64'
+                to: 's3://releases.republicprotocol.com/darknode-cli/darknode_darwin_amd64-test'
+                arguments: '--acl public-read'
+            - aws-s3/copy:
+                from: ~/.go_workspace/src/github.com/renproject/darknode-cli/scripts/install.sh
+                to: 's3://releases.republicprotocol.com/darknode-cli/install-test.sh'
+                arguments: '--acl public-read'
+            - aws-s3/copy:
+                from: ~/.go_workspace/src/github.com/renproject/darknode-cli/scripts/update.sh
+                to: 's3://releases.republicprotocol.com/darknode-cli/update-test.sh'
+                arguments: '--acl public-read'
+            - run:
+                name: build the resource pack
+                command: |
+                    zip -r resources.zip target/resources
+            - aws-s3/copy:
+                from: ~/.go_workspace/src/github.com/renproject/darknode-cli/resources.zip
+                to: 's3://releases.republicprotocol.com/darknode-cli/resources-test.zip'
                 arguments: '--acl public-read'
 
 workflows:
@@ -89,6 +105,6 @@ workflows:
     build:
         jobs:
             - deploy:
-                filters:
-                    branches:
-                        only: master
+#                filters:
+#                    branches:
+#                        only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,9 @@ jobs:
             - run:
                 name: build the resource pack
                 command: |
-                    cd target/resources
+                    cd target/
                     zip -r resources.zip resources
+                    mv resources.zip ../
             - aws-s3/copy:
                 from: ~/.go_workspace/src/github.com/renproject/darknode-cli/resources.zip
                 to: 's3://releases.republicprotocol.com/darknode-cli/resources-test.zip'

--- a/cmd/cmds.go
+++ b/cmd/cmds.go
@@ -93,6 +93,7 @@ func startSingleNode(name string) error {
 	if err != nil {
 		return err
 	}
+
 	startScript := "systemctl --user start darknode"
 	keyPairPath := nodePath + "/ssh_keypair"
 	if err := run("ssh", "-i", keyPairPath, "darknode@"+ip, "-oStrictHostKeyChecking=no", startScript); err != nil {

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -79,7 +79,11 @@ func destroyNode(ctx *cli.Context) error {
 	}
 	fmt.Printf("%sDestroying your darknode ...%s\n", RESET, RESET)
 
-	destroy := fmt.Sprintf("cd %v && terraform 0.12upgrade --yes && terraform destroy --force && find . -type f -not -name 'config.json' -delete", nodePath)
+	// Try updating the terraform config if it's from an old version
+	updateTerraformConfig(nodePath)
+
+	// Destroy the instance through terrafrom
+	destroy := fmt.Sprintf("cd %v && terraform destroy --force && find . -type f -not -name 'config.json' -delete", nodePath)
 	return run("bash", "-c", destroy)
 }
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -79,7 +79,7 @@ func destroyNode(ctx *cli.Context) error {
 	}
 	fmt.Printf("%sDestroying your darknode ...%s\n", RESET, RESET)
 
-	destroy := fmt.Sprintf("cd %v && terraform destroy --force && find . -type f -not -name 'config.json' -delete", nodePath)
+	destroy := fmt.Sprintf("cd %v && terraform 0.12upgrade --yes && terraform destroy --force && find . -type f -not -name 'config.json' -delete", nodePath)
 	return run("bash", "-c", destroy)
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "Darknode CLI"
 	app.Usage = "A command-line tool for managing Darknodes."
-	app.Version = "2.2.11"
+	app.Version = "2.3.0"
 
 	// Define sub-commands
 	app.Commands = []cli.Command{

--- a/cmd/resize.go
+++ b/cmd/resize.go
@@ -65,7 +65,7 @@ func resizeAwsInstance(tfFile []byte, nodePath, tfPath, newSize string) error {
 
 	// Start running terraform
 	fmt.Printf("\n%sResizing dark nodes ... %s\n", RESET, RESET)
-	apply := fmt.Sprintf("cd %v && terraform apply -auto-approve -no-color", nodePath)
+	apply := fmt.Sprintf("cd %v && terraform 0.12upgrade --yes && terraform apply -auto-approve -no-color", nodePath)
 	err = run("bash", "-c", apply)
 	if err != nil {
 		// revert the `main.tf` file if fail to resize the droplet
@@ -85,7 +85,7 @@ func resizeAwsInstance(tfFile []byte, nodePath, tfPath, newSize string) error {
 
 func resizeDoInstance(tfFile []byte, nodePath, tfPath, newSize string) error {
 	// Mark the droplet as tainted for recreating the droplet
-	taint := fmt.Sprintf("cd %v && terraform taint digitalocean_droplet.darknode", nodePath)
+	taint := fmt.Sprintf("cd %v && terraform 0.12upgrade --yes && terraform taint digitalocean_droplet.darknode", nodePath)
 	err := run("bash", "-c", taint)
 	if err != nil {
 		fmt.Println("[warning] fail to taint the darknode which might not be exist.")

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -212,4 +213,10 @@ func redirectCommand() (string, error) {
 	default:
 		return "", ErrUnsupportedOS
 	}
+}
+
+// try to update the config and not care about successfully or not .
+func updateTerraformConfig(path string) {
+	check := fmt.Sprintf("cd %v && terraform 0.12upgrade --yes", path)
+	exec.Command("bash", "-c", check).Run() // ignore the error
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -67,28 +67,6 @@ func getID(nodeDirectory string) (string, error) {
 	return multi.ValueForProtocol(identity.RepublicCode)
 }
 
-// getNodesByTag return the names of the nodes having the given tag.
-func getNodesByTag(tag string) ([]string, error) {
-	files, err := ioutil.ReadDir(Directory + "/darknodes")
-	if err != nil {
-		return nil, err
-	}
-	nodes := make([]string, 0)
-
-	for _, f := range files {
-		tagFile := path.Join(Directory, "darknodes", f.Name(), "tags.out")
-		tags, err := ioutil.ReadFile(tagFile)
-		if err != nil {
-			continue
-		}
-		if strings.Contains(string(tags), tag) {
-			nodes = append(nodes, f.Name())
-		}
-	}
-
-	return nodes, nil
-}
-
 // getNodesByTags return the names of the nodes having the given tags.
 func getNodesByTags(tags string) ([]string, error) {
 	files, err := ioutil.ReadDir(Directory + "/darknodes")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,10 +23,10 @@ cputype="$(uname -m)"
 
 # download darknode binary depending on the system and architecture
 if [ "$ostype" = 'Linux' -a "$cputype" = 'x86_64' ]; then
-    TERRAFORM_URL='https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_linux_amd64.zip'
+    TERRAFORM_URL='https://releases.hashicorp.com/terraform/0.12.3/terraform_0.12.3_linux_amd64.zip'
     curl -s 'https://releases.republicprotocol.com/darknode-cli/darknode_linux_amd64' > ./bin/darknode
 elif [ "$ostype" = 'Darwin' -a "$cputype" = 'x86_64' ]; then
-    TERRAFORM_URL='https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_darwin_amd64.zip'
+    TERRAFORM_URL='https://releases.hashicorp.com/terraform/0.12.3/terraform_0.12.3_darwin_amd64.zip'
     curl -s 'https://releases.republicprotocol.com/darknode-cli/darknode_darwin_amd64' > ./bin/darknode
 else
    echo 'unsupported OS type or architecture'

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -16,14 +16,24 @@ cputype="$(uname -m)"
 
 # Download the latest binary darknode
 if [ "$ostype" = 'Linux' -a "$cputype" = 'x86_64' ]; then
+    TERRAFORM_URL='https://releases.hashicorp.com/terraform/0.12.3/terraform_0.12.3_linux_amd64.zip'
     curl -s 'https://releases.republicprotocol.com/darknode-cli/darknode_linux_amd64' > ./bin/darknode
 elif [ "$ostype" = 'Darwin' -a "$cputype" = 'x86_64' ]; then
+    TERRAFORM_URL='https://releases.hashicorp.com/terraform/0.12.3/terraform_0.12.3_darwin_amd64.zip'
     curl -s 'https://releases.republicprotocol.com/darknode-cli/darknode_darwin_amd64' > ./bin/darknode
 else
    echo 'unsupported OS type or architecture'
    exit 1
 fi
 
+# download terraform
+curl -s "$TERRAFORM_URL" > terraform.zip
+unzip terraform
+chmod +x terraform
+mv terraform bin/terraform
+rm terraform.zip
+
+# update darknode binary
 chmod +x bin/darknode
 rm resources.zip
 

--- a/target/resources/instance/aws/aws.tmpl
+++ b/target/resources/instance/aws/aws.tmpl
@@ -43,9 +43,9 @@ variable "allocation_id"{
 }
 
 provider "aws" {
-  region     = "${var.region}"
-  access_key = "${var.access_key}"
-  secret_key = "${var.secret_key}"
+  region     = var.region
+  access_key = var.access_key
+  secret_key = var.secret_key
 }
 
 data "aws_ami" "ubuntu" {
@@ -92,8 +92,8 @@ resource "aws_security_group" "darknode" {
 }
 
 resource "aws_key_pair" "darknode" {
-  key_name   = "${var.name}"
-  public_key = "${var.ssh_public_key}"
+  key_name   = var.name
+  public_key = var.ssh_public_key
 }
 
 output "multiaddress" {
@@ -102,8 +102,8 @@ output "multiaddress" {
 
 {{if .AllocationID}}
 resource "aws_eip_association" "eip_assoc" {
-  instance_id   = "${aws_instance.darknode.id}"
-  allocation_id = "${var.allocation_id}"
+  instance_id   = aws_instance.darknode.id
+  allocation_id = var.allocation_id
 
   provisioner "local-exec" {
     command = "echo /ip4/${aws_eip_association.eip_assoc.public_ip}/tcp/${var.port}/republic/${var.address} > multiAddress.out"
@@ -111,19 +111,19 @@ resource "aws_eip_association" "eip_assoc" {
 }{{else}}{{end}}
 
 resource "aws_instance" "darknode" {
-  ami             = "${data.aws_ami.ubuntu.id}"
-  instance_type   = "${var.instance_type}"
-  key_name        = "${aws_key_pair.darknode.key_name}"
-  security_groups = ["${aws_security_group.darknode.name}"]
-
+  ami             = data.aws_ami.ubuntu.id
+  instance_type   = var.instance_type
+  key_name        = aws_key_pair.darknode.key_name
+  security_groups = [aws_security_group.darknode.name]
 
   provisioner "remote-exec" {
     script = "${var.path}/scripts/init.sh"
 
     connection {
+      host        = coalesce(self.public_ip, self.private_ip)
       type        = "ssh"
       user        = "ubuntu"
-      private_key = "${file("${var.ssh_private_key_path}")}"
+      private_key = file("${var.ssh_private_key_path}")
     }
   }
 
@@ -132,6 +132,7 @@ resource "aws_instance" "darknode" {
     destination = "$HOME/darknode-config.json"
 
     connection {
+      host        = coalesce(self.public_ip, self.private_ip)
       type        = "ssh"
       user        = "darknode"
       private_key = "${file("${var.ssh_private_key_path}")}"
@@ -142,9 +143,10 @@ resource "aws_instance" "darknode" {
     script = "${var.path}/scripts/install.sh"
 
     connection {
+      host        = coalesce(self.public_ip, self.private_ip)
       type        = "ssh"
       user        = "darknode"
-      private_key = "${file("${var.ssh_private_key_path}")}"
+      private_key = file("${var.ssh_private_key_path}")
     }
   }
 

--- a/target/resources/instance/do/do.tmpl
+++ b/target/resources/instance/do/do.tmpl
@@ -31,31 +31,33 @@ variable "pvt_key" {
 }
 
 provider "digitalocean" {
-  token = "${var.do_token}"
+  token = var.do_token
 }
 
 resource "digitalocean_ssh_key" "darknode" {
-  name       = "${var.name}"
-  public_key = "${file("${var.pub_key}")}"
+  name       = var.name
+  public_key = file(var.pub_key)
 }
 
 resource "digitalocean_droplet" "darknode" {
-  provider = "digitalocean"
-  image = "ubuntu-18-04-x64"
-  name = "${var.name}"
-  region = "${var.region}"
-  size = "${var.size}"
-  ssh_keys = [
-    "${digitalocean_ssh_key.darknode.id}"
+  provider   = digitalocean
+  image      = "ubuntu-18-04-x64"
+  name       = var.name
+  region     = var.region
+  size       = var.size
+  monitoring = true
+  ssh_keys   = [
+    digitalocean_ssh_key.darknode.id
   ]
 
   provisioner "remote-exec" {
     script = "${var.path}/scripts/init.sh"
 
     connection {
+      host        = self.ipv4_address
       type        = "ssh"
       user        = "root"
-      private_key = "${file("${var.pvt_key}")}"
+      private_key = file(var.pvt_key)
     }
   }
 
@@ -64,9 +66,10 @@ resource "digitalocean_droplet" "darknode" {
     destination = "$HOME/darknode-config.json"
 
     connection {
-      type = "ssh"
-      user = "darknode"
-      private_key = "${file("${var.pvt_key}")}"
+      host        = self.ipv4_address
+      type        = "ssh"
+      user        = "darknode"
+      private_key = file(var.pvt_key)
     }
   }
 
@@ -74,9 +77,10 @@ resource "digitalocean_droplet" "darknode" {
     script = "${var.path}/scripts/install.sh"
 
     connection {
-      type = "ssh"
-      user = "darknode"
-      private_key = "${file("${var.pvt_key}")}"
+      host        = self.ipv4_address
+      type        = "ssh"
+      user        = "darknode"
+      private_key = file(var.pvt_key)
     }
   }
 


### PR DESCRIPTION
- Updates the CLI to use the latest version of `terraform` (0.12.3). (see issue #23).
- Update installation and update script to update the terraform version.
- Add monitoring to digital ocean droplet (see issue #18) 
- Make the new CLI compatible with old terraform config files.