### PR TITLE
Update command

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -14,6 +14,12 @@ import (
 	"github.com/urfave/cli"
 )
 
+// Location of the update script
+const updateScriptLocation = "/home/darknode/.darknode/bin/update.sh"
+
+// The command to execute to trigger an update. We use the -f to force an update.
+var updateCommand = fmt.Sprintf("/bin/bash %s -f", updateScriptLocation)
+
 // updateNode updates the Darknode to the latest release. It can also be used
 // to update the config file of the darknode.
 func updateNode(ctx *cli.Context) error {
@@ -95,11 +101,7 @@ func updateSingleNode(name, branch string, updateConfig bool) error {
 		fmt.Printf("%sConfig of [%s] has been updated to the local version.%s\n", GREEN, name, RESET)
 	}
 
-	udpate, err := ioutil.ReadFile(path.Join(Directory, "scripts", "update.sh"))
-	if err != nil {
-		return err
-	}
-	err = run("ssh", "-i", keyPairPath, "darknode@"+ip, "-oStrictHostKeyChecking=no", string(udpate))
+	err = run("ssh", "-i", keyPairPath, "darknode@"+ip, "-oStrictHostKeyChecking=no", updateCommand)
 	if err != nil {
 		return err
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -105,7 +105,7 @@ func updateSingleNode(name, branch string, updateConfig bool) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s[%s] has been updated to the latest version on %s branch.%s \n", GREEN, name, branch, RESET)
+	fmt.Printf("%s[%s] has been updated to the latest version.%s \n", GREEN, name, RESET)
 	return nil
 }
 


### PR DESCRIPTION
There exists an update script on the darknodes at `${HOME}/.darknode/bin/update.sh`. It periodically checks the latest IPNS hash resolution and updates the binary and restarts the darknode service if the hash is different.

The `darknode update` command is used to force trigger and update.
