### PR TITLE
v3.0.2

### DIFF
--- a/cmd/provider/do_template.go
+++ b/cmd/provider/do_template.go
@@ -81,6 +81,7 @@ resource "digitalocean_droplet" "darknode" {
       "sudo ufw allow 18514/tcp", 
       "sudo ufw allow 18515/tcp", 
       "sudo ufw --force enable",
+	  "curl -sSL https://repos.insights.digitalocean.com/install.sh | sudo bash",	
 	]
 
     connection {

--- a/darknode/config.go
+++ b/darknode/config.go
@@ -55,7 +55,9 @@ func NewConfig(network Network) (Config, error) {
 		Bootstraps:             network.BootstrapNodes(),
 		DNRAddress:             network.DnrAddress(),
 		ShifterRegistryAddress: network.ShiftRegistryAddress(),
-		PeerOptions:            &aw.PeerOptions{},
+		PeerOptions:            &aw.PeerOptions{
+			DisablePeerDiscovery: true,
+		},
 	}, nil
 }
 

--- a/darknode/config.go
+++ b/darknode/config.go
@@ -55,7 +55,7 @@ func NewConfig(network Network) (Config, error) {
 		Bootstraps:             network.BootstrapNodes(),
 		DNRAddress:             network.DnrAddress(),
 		ShifterRegistryAddress: network.ShiftRegistryAddress(),
-		PeerOptions:            &aw.PeerOptions{
+		PeerOptions: &aw.PeerOptions{
 			DisablePeerDiscovery: true,
 		},
 	}, nil


### PR DESCRIPTION
Hotfix :

- set `DisablePeerDiscovery` to true when initializing a new darknode config. 
- manually install the metrics agent for digital ocean to enable detail monitoring