### PR TITLE
v3.0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ commands:
                   wget https://github.com/tcnksm/ghr/releases/download/v0.13.0/ghr_v0.13.0_linux_amd64.tar.gz
                   tar xvzf ghr_v0.13.0_linux_amd64.tar.gz
                   mv ghr_v0.13.0_linux_amd64/ghr ghr
-                  ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete 3.0.1 ../artifacts/
+                  ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete 3.0.3 ../artifacts/
     test_env:
         description: "Push the binaries to aws s3, so that we can test before releasing."
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,42 +4,82 @@
 version: 2.1
 
 orbs:
-    core: ren/core@0.0.1
+    aws-s3: circleci/aws-s3@1.0.11
 
 _defaults: &defaults
     docker:
         - image: techknowlogick/xgo:latest
 
+commands:
+    cross_compile:
+        description: "Cross compile binaries for different os and archs"
+        steps:
+            - run:
+                  name: Build binaries
+                  command: |
+                      cd cmd
+                      go build -o darknode .
+                      mv darknode ../artifacts/darknode_linux_amd64
+                      env GOOS=linux CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc-6 CXX=aarch64-linux-gnu-g++-6 GOARCH=arm64 go build -o darknode .
+                      mv darknode ../artifacts/darknode_linux_arm
+                      env GOOS=darwin CGO_ENABLED=1 CC=o64-clang CXX=o64-clang++ GOARCH=amd64 go build -o darknode .
+                      mv darknode ../artifacts/darknode_darwin_amd64
+    release:
+        description: "Publish a new release"
+        steps:
+            - run:
+                  wget https://github.com/tcnksm/ghr/releases/download/v0.13.0/ghr_v0.13.0_linux_amd64.tar.gz
+                  tar xvzf ghr_v0.13.0_linux_amd64.tar.gz
+                  mv ghr_v0.13.0_linux_amd64/ghr ghr
+                  ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete 3.0.1 ../artifacts/
+    test_env:
+        description: "Push the binaries to aws s3, so that we can test before releasing."
+        steps:
+            - run:
+                  name: install AWS CLI
+                  command: |
+                      apt-get -y install python3
+                      apt -y install python-pip python-dev
+                      pip install awscli
+            - aws-s3/sync:
+                  from: ./artifacts
+                  to: 's3://releases.republicprotocol.com/darknode-cli/temp/'
+                  arguments: '--acl public-read'
+                  overwrite: true
+
 jobs:
-    deploy:
+    deployment:
         <<: *defaults
         steps:
             - checkout
             - run:
-                name: install tools
-                command: |
-                    go vet ./...
+                  name: install tools
+                  command: |
+                      go vet ./...
+            - cross_compile
+            - release
+    test:
+        <<: *defaults
+        steps:
+            - checkout
             - run:
-                name: Build binaries
-                command: |
-                    cd cmd
-                    go build -o darknode .
-                    mv darknode ../artifacts/darknode_linux_amd64
-                    env GOOS=linux CGO_ENABLED=1 CC=arm-linux-gnueabi-gcc-6 GOARCH=arm go build -o darknode .
-                    mv darknode ../artifacts/darknode_linux_arm
-                    env GOOS=darwin CGO_ENABLED=1 CC=o64-clang GOARCH=amd64 go build -o darknode .
-                    mv darknode ../artifacts/darknode_darwin_amd64
-                    wget https://github.com/tcnksm/ghr/releases/download/v0.13.0/ghr_v0.13.0_linux_amd64.tar.gz
-                    tar xvzf ghr_v0.13.0_linux_amd64.tar.gz
-                    mv ghr_v0.13.0_linux_amd64/ghr ghr
-                    ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete 3.0.2 ../artifacts/
+                  name: install tools
+                  command: |
+                      go vet ./...
+            - cross_compile
+            - test_env
 
 workflows:
     version: 2.1
     deployment:
         jobs:
-            - deploy:
-                filters:
-                    branches:
-                        only:
-                            - master
+            - deployment:
+                  filters:
+                      branches:
+                          only:
+                              - master
+            - test:
+                  filters:
+                      branches:
+                          ignore:
+                              - master

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,7 +25,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "Darknode CLI"
 	app.Usage = "A command-line tool for managing Darknodes."
-	app.Version = "3.0.2"
+	app.Version = "3.0.3"
 
 	// Fetch latest release and check if our version is bebind.
 	checkUpdates(app.Version)

--- a/cmd/provider/aws_template.go
+++ b/cmd/provider/aws_template.go
@@ -115,13 +115,13 @@ resource "aws_instance" "darknode" {
   provisioner "remote-exec" {
 
 	inline = [
+      "set -x",
       "sudo adduser darknode --gecos \",,,\" --disabled-password",
       "sudo rsync --archive --chown=darknode:darknode ~/.ssh /home/darknode",
-      "sudo DEBIAN_FRONTEND=noninteractive apt-get -y update",
-      "sudo DEBIAN_FRONTEND=noninteractive apt-get -y upgrade",
-      "sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade",
-      "sudo DEBIAN_FRONTEND=noninteractive apt-get -y auto-remove",
-      "sudo apt-get update",
+      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y update; do sleep 2; done",
+      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y upgrade; do sleep 2; done",
+      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade; do sleep 2; done",
+      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y autoremove; do sleep 2; done",
       "sudo apt-get -y install jq",
       "sudo apt-get install ufw",
       "sudo ufw limit 22/tcp",

--- a/cmd/provider/aws_template.go
+++ b/cmd/provider/aws_template.go
@@ -116,12 +116,13 @@ resource "aws_instance" "darknode" {
 
 	inline = [
       "set -x",
+      "until sudo apt update; do sleep 2; done",
       "sudo adduser darknode --gecos \",,,\" --disabled-password",
       "sudo rsync --archive --chown=darknode:darknode ~/.ssh /home/darknode",
-      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y update; do sleep 2; done",
-      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y upgrade; do sleep 2; done",
-      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade; do sleep 2; done",
-      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y autoremove; do sleep 2; done",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get -y update",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get -y upgrade",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get -y autoremove",
       "sudo apt-get -y install jq",
       "sudo apt-get install ufw",
       "sudo ufw limit 22/tcp",

--- a/cmd/provider/do_template.go
+++ b/cmd/provider/do_template.go
@@ -68,6 +68,7 @@ resource "digitalocean_droplet" "darknode" {
   provisioner "remote-exec" {
 	
 	inline = [
+      "until sudo apt update; do sleep 2; done",
       "sudo adduser darknode --gecos \",,,\" --disabled-password",
       "sudo rsync --archive --chown=darknode:darknode ~/.ssh /home/darknode",
       "sudo DEBIAN_FRONTEND=noninteractive apt-get -y update",

--- a/cmd/provider/do_template.go
+++ b/cmd/provider/do_template.go
@@ -70,15 +70,17 @@ resource "digitalocean_droplet" "darknode" {
 	
 	inline = [
       "set -x",
+      "until sudo apt update; do sleep 2; done",
+      "until sudo apt-get -y update; do sleep 2; done",
       "sudo adduser darknode --gecos \",,,\" --disabled-password",
       "sudo rsync --archive --chown=darknode:darknode ~/.ssh /home/darknode",
-	  "sudo snap install jq",
-      "sudo snap install ufw",
+	  "curl -sSL https://repos.insights.digitalocean.com/install.sh | sudo bash",
+      "sudo apt-get install ufw",
       "sudo ufw limit 22/tcp",
       "sudo ufw allow 18514/tcp", 
       "sudo ufw allow 18515/tcp", 
       "sudo ufw --force enable",
-	  "curl -sSL https://repos.insights.digitalocean.com/install.sh | sudo bash",	
+      "until sudo sudo apt-get -y install jq; do sleep 2; done",
 	]
 
     connection {

--- a/cmd/provider/do_template.go
+++ b/cmd/provider/do_template.go
@@ -80,7 +80,7 @@ resource "digitalocean_droplet" "darknode" {
       "sudo ufw allow 18514/tcp", 
       "sudo ufw allow 18515/tcp", 
       "sudo ufw --force enable",
-      "until sudo sudo apt-get -y install jq; do sleep 2; done",
+      "until sudo apt-get -y install jq; do sleep 2; done",
 	]
 
     connection {

--- a/cmd/provider/do_template.go
+++ b/cmd/provider/do_template.go
@@ -70,15 +70,10 @@ resource "digitalocean_droplet" "darknode" {
 	
 	inline = [
       "set -x",
-      "until sudo apt update; do sleep 2; done",
       "sudo adduser darknode --gecos \",,,\" --disabled-password",
       "sudo rsync --archive --chown=darknode:darknode ~/.ssh /home/darknode",
-      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y update; do sleep 2; done",
-      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y upgrade; do sleep 2; done",
-      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade; do sleep 2; done",
-      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y autoremove; do sleep 2; done",
-      "sudo apt-get -y install jq",
-      "sudo apt-get install ufw",
+	  "sudo snap install jq",
+      "sudo snap install ufw",
       "sudo ufw limit 22/tcp",
       "sudo ufw allow 18514/tcp", 
       "sudo ufw allow 18515/tcp", 

--- a/cmd/provider/do_template.go
+++ b/cmd/provider/do_template.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -25,9 +26,9 @@ func (p providerDo) tfConfig(name, region, droplet, ipfs string) error {
 		Token:      p.token,
 		Region:     region,
 		Size:       droplet,
-		ConfigPath: filepath.Join(util.NodePath(name), "config.json"),
-		PubKeyPath: filepath.Join(util.NodePath(name), "ssh_keypair.pub"),
-		PriKeyPath: filepath.Join(util.NodePath(name), "ssh_keypair"),
+		ConfigPath: fmt.Sprintf("~/.darknode/darknodes/%v/config.json", name),
+		PubKeyPath: fmt.Sprintf("~/.darknode/darknodes/%v/ssh_keypair.pub", name),
+		PriKeyPath: fmt.Sprintf("~/.darknode/darknodes/%v/ssh_keypair", name),
 		IPFS:       ipfs,
 	}
 
@@ -68,14 +69,14 @@ resource "digitalocean_droplet" "darknode" {
   provisioner "remote-exec" {
 	
 	inline = [
+      "set -x",
       "until sudo apt update; do sleep 2; done",
       "sudo adduser darknode --gecos \",,,\" --disabled-password",
       "sudo rsync --archive --chown=darknode:darknode ~/.ssh /home/darknode",
-      "sudo DEBIAN_FRONTEND=noninteractive apt-get -y update",
-      "sudo DEBIAN_FRONTEND=noninteractive apt-get -y upgrade",
-      "sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade",
-      "sudo DEBIAN_FRONTEND=noninteractive apt-get -y auto-remove",
-      "sudo apt-get update",
+      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y update; do sleep 2; done",
+      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y upgrade; do sleep 2; done",
+      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade; do sleep 2; done",
+      "until sudo DEBIAN_FRONTEND=noninteractive apt-get -y autoremove; do sleep 2; done",
       "sudo apt-get -y install jq",
       "sudo apt-get install ufw",
       "sudo ufw limit 22/tcp",
@@ -131,5 +132,5 @@ output "provider" {
 }
 
 output "ip" {
-  value = "${digitalocean_droplet.darknode.ipv4_address}"
+  value = digitalocean_droplet.darknode.ipv4_address
 }`

--- a/cmd/provider/gcp.go
+++ b/cmd/provider/gcp.go
@@ -132,8 +132,8 @@ package provider
 // 	Project       string
 // 	Address       string
 // 	MachineType   string
-// 	SshPubKey     string
-// 	SshPriKeyPath string
+// 	PubKeyPath     string
+// 	PriKeyPath string
 // 	Credentials   string
 // 	Port          string
 // 	Path          string
@@ -192,8 +192,8 @@ package provider
 // 		Project:       projectId,
 // 		Address:       id.String(),
 // 		MachineType:   machine_type,
-// 		SshPubKey:     strings.TrimSpace(StringfySshPubkey(pubKey)),
-// 		SshPriKeyPath: path.Join(nodePath, "ssh_keypair"),
+// 		PubKeyPath:     strings.TrimSpace(StringfySshPubkey(pubKey)),
+// 		PriKeyPath: path.Join(nodePath, "ssh_keypair"),
 // 		Credentials:   credentialPath,
 // 		Path:          Directory,
 // 		AllocationID:  ctx.String("aws-elastic-ip"),

--- a/cmd/resize.go
+++ b/cmd/resize.go
@@ -42,7 +42,7 @@ func resize(ctx *cli.Context) error {
 		replacement := fmt.Sprintf(`instance_type   = "%v"`, newSize)
 		return applyChanges(name, RegexAws, replacement)
 	case provider.NameDo:
-		replacement := fmt.Sprintf(`size       = "%v"`, newSize)
+		replacement := fmt.Sprintf(`size        = "%v"`, newSize)
 		return applyChanges(name, RegexDo, replacement)
 	case provider.NameGcp:
 		panic("unsupported yet")

--- a/util/utils.go
+++ b/util/utils.go
@@ -219,7 +219,7 @@ func OpenInBrowser(url string) error {
 	case "darwin":
 		SilentRun("open", url)
 	case "linux":
-		if CheckWSL(){
+		if CheckWSL() {
 			SilentRun("cmd.exe", "/C", "start", url)
 		} else {
 			SilentRun("xdg-open", url)
@@ -229,7 +229,7 @@ func OpenInBrowser(url string) error {
 }
 
 func CheckWSL() bool {
-	file, err:= ioutil.ReadFile("/proc/version")
+	file, err := ioutil.ReadFile("/proc/version")
 	if err != nil {
 		return false
 	}

--- a/util/utils.go
+++ b/util/utils.go
@@ -213,14 +213,27 @@ func RemoteRunWithUser(name, script, user string) error {
 	return session.Run(script)
 }
 
+// OpenInBrowser tries to open the url from the
 func OpenInBrowser(url string) error {
 	switch runtime.GOOS {
 	case "darwin":
-		return SilentRun("open", url)
+		SilentRun("open", url)
 	case "linux":
-		return SilentRun("xdg-open", url)
+		if CheckWSL(){
+			SilentRun("cmd.exe", "/C", "start", url)
+		} else {
+			SilentRun("xdg-open", url)
+		}
 	}
 	return nil
+}
+
+func CheckWSL() bool {
+	file, err:= ioutil.ReadFile("/proc/version")
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(file), "Microsoft")
 }
 
 // RegisterUrl returns the url for registering a particular darknode.

--- a/util/utils.go
+++ b/util/utils.go
@@ -213,7 +213,7 @@ func RemoteRunWithUser(name, script, user string) error {
 	return session.Run(script)
 }
 
-// OpenInBrowser tries to open the url from the
+// OpenInBrowser tries to open the url with system default browser. It ignores the error if failing.
 func OpenInBrowser(url string) error {
 	switch runtime.GOOS {
 	case "darwin":


### PR DESCRIPTION
- Fix deployment sometimes could fail on digital ocean. 
 > The error message is`Could not get lock /var/lib/apt/lists/lock - open (11: Resource temporarily unavailable)`, detail explanation could be found [here](https://www.digitalocean.com/community/questions/want-to-install-monitoring-agent-but-i-am-getting-unable-to-lock-the-administration-directory-var-lib-dpkg-is-another-process-using-it)
- Now WSL can automatically open registering link after a successful deployment.
- Hide the red error message when cannot find any command to open the registering link. 
