### PR TITLE
Add echo at start of script

### DIFF
--- a/artifacts/install.sh
+++ b/artifacts/install.sh
@@ -5,6 +5,8 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
+echo "Installing Darknode CLI..."
+
 # Install unzip if command not found
 if ! [ -x "$(command -v unzip)" ];then
   sudo apt-get install unzip

--- a/artifacts/update.sh
+++ b/artifacts/update.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+echo "Updating Darknode CLI..."
+
 # Check the os type and cpu architecture
 ostype="$(uname -s)"
 cputype="$(uname -m)"


### PR DESCRIPTION
This PR updates the `install.sh` and `update.sh` scripts to echo "Intalling Darknode CLI" and "Updating Darknode CLI" respectively.

The scripts can take a while so the logs let the user know that the script is working.