### PR TITLE
Added Digital Ocean platform native firewall rules

### DIFF
--- a/cmd/provider/do_template.go
+++ b/cmd/provider/do_template.go
@@ -133,6 +133,36 @@ resource "digitalocean_droplet" "darknode" {
   }
 }
 
+resource "digitalocean_firewall" "darknode" {
+  name       = "{{.Name}}-firewall"
+
+  droplet_ids = [digitalocean_droplet.darknode.id]
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "18514-18515"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}
+
 output "provider" {
   value = "do"
 }


### PR DESCRIPTION
Use the provider's native firewall to secure the VM

Edit needed:
- Could tighten the outbound_rule if needed. (i.e. is `udp` needed?)