### PR TITLE
Adds provider for digitalocean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
               run: |
                   go build -o darknode_linux_amd64 -ldflags "-s -w -X main.BinaryVersion=${GIT_TAG_NAME}" ./cmd/*.go
                   mv darknode_linux_amd64 ./artifacts/
-                  env GOOS=linux CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc-6 CXX=aarch64-linux-gnu-g++-6 GOARCH=arm64 go build -o darknode_linux_arm -ldflags "-s -w -X main.BinaryVersion=${GIT_TAG_NAME}" ./cmd/*.go
+                  env GOOS=linux CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc-9 CXX=aarch64-linux-gnu-g++-6 GOARCH=arm64 go build -o darknode_linux_arm -ldflags "-s -w -X main.BinaryVersion=${GIT_TAG_NAME}" ./cmd/*.go
                   mv darknode_linux_arm ./artifacts/
                   env GOOS=darwin CGO_ENABLED=1 CC=o64-clang CXX=o64-clang++ GOARCH=amd64 go build -o darknode_darwin_amd64 -ldflags "-s -w -X main.BinaryVersion=${GIT_TAG_NAME}" ./cmd/*.go
                   mv darknode_darwin_amd64 ./artifacts/

--- a/cmd/provider/do_template.go
+++ b/cmd/provider/do_template.go
@@ -49,9 +49,9 @@ var doTemplate = `
 terraform {
   required_providers {
     digitalocean = {
-	  source = "digitalocean/digitalocean"
-	  version = "~> 2.0"
-	}
+      source = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
   }
 }
 

--- a/cmd/provider/do_template.go
+++ b/cmd/provider/do_template.go
@@ -46,6 +46,15 @@ func (p providerDo) tfConfig(name, region, droplet, latestVersion string) error 
 }
 
 var doTemplate = `
+terraform {
+  required_providers {
+    digitalocean = {
+	  source = "digitalocean/digitalocean"
+	  version = "~> 2.0"
+	}
+  }
+}
+
 provider "digitalocean" {
   token = "{{.Token}}"
 }


### PR DESCRIPTION
 The terraform provider for digitalocean got moved to a partnered third party, and no longer exists in hashicorps domain. Everything still works under the new provider, just lets that flow work now